### PR TITLE
docs: add GitHub templates for PR and bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, triage
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Provide output from `sessionInfo()`**
+```r
+# paste output within this block for formatting
+```
+
+* [ ] I have checked that the bug is not already described in [open issues](https://github.com/ssi-dk/SCDB/issues?q=is%3Aopen)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,56 @@
+<!-- Thanks for contributing!
+
+Before creating your pull request, please read this comment in its entirety.
+This will help with reviewing the changes and hopefully merge your changes into
+the repository as smoothly as possible.
+
+
+# Pull request title
+
+Your title should be short yet exhaustive. Hopefully, this comes easily,
+as pull requests should be single-topic as possible.
+
+
+# Issue references
+Ideally, the PR addresses an issue. If so, please reference the issue number
+in the PR title and/or the body text. See also "Linking a pull request to an issue"
+linked in the "Intent" section.
+
+
+# Automated tests
+The package supports several backends, and tests the coverage of these.
+If the pull request modifies code which is used by multiple backends, please
+test the changes locally before submitting a pull request if possible.
+-->
+
+### Intent
+
+> Describe briefly what problem the pull request resolves, or new features it
+> introduces.
+> Please link to issues if possible
+> (see also ["Linking a pull request to an issue"](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)).
+>
+> Trivial changes, like fixing a typo, does not need an issue. 
+
+
+### Approach
+
+> How was the issue resolved?
+> Describe the approach taken; describe any non-obvious considerations made in
+> choosing this approach.
+>
+> If the change cannot or will not be covered by a test, please explain why.
+
+
+### Known issues
+> If any known issues are introduced by this pull request, please let us know.
+> Code is rarely perfect, and a pull request is still welcome if the fix is
+> bigger than the new bug.
+
+
+### Checklist
+
+* [ ] The PR passes all local unit tests
+* [ ] I have documented any new features introduced
+* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
+* [ ] A reviewer is assigned to this PR


### PR DESCRIPTION
This PR adds templates for Pull requests and for Bug reports
(Taken from ssi-dk/SCDB)