### PR TITLE
fix(DiseasystoreGoogleCovid19): allow URLs as source_conn -- part 2

### DIFF
--- a/R/feature_store_helpers.R
+++ b/R/feature_store_helpers.R
@@ -103,9 +103,17 @@ source_conn_path <- function(source_conn, file) {
 
   # Determine the type of location
   if (checkmate::test_directory_exists(source_conn)) { # source_conn is a directory
-    file_location <- file.path(source_conn, file)
+    # If source_conn is a dirctory, look for files in the folder and keep the ones that match the requested file
+    # This way, if the file exists in a zipped form, it is still retrieved
+    matching_file <- purrr::keep(dir(source_conn), ~ startsWith(., file)) |>
+      purrr::pluck(1) # Ensure we only have one match
+
+    if (is.null(matching_file)) stop(file, " could not be found in ", source_conn)
+
+    file_location <- file.path(source_conn, matching_file)
+
   } else if (checkmate::test_character(source_conn, pattern = url_regex)) { # source_conn is a URL
-    file_location <- paste0(source_conn, file)
+    file_location <- paste0(stringr::str_remove(source_conn, "/$"), "/", file)
   } else {
     stop("source_conn could not be parsed to valid directory or URL\n")
   }

--- a/R/feature_store_helpers.R
+++ b/R/feature_store_helpers.R
@@ -84,3 +84,31 @@ age_labels <- function(age_cuts) {
                  c(rep("-", length(age_cuts)), "+"),
                  c(stringr::str_pad(age_cuts - 1, width, pad = "0"), ""))
 }
+
+
+#' File path helper for source_conn
+#'
+#' @description
+#'   This helper determines whether source_conn is a file path or URL and creates the full path to the
+#'   the file as needed based on the type of source_conn
+#' @param source_conn File location (path or URL)
+#' @param file Name of the file at the location
+#' @noRd
+source_conn_path <- function(source_conn, file) {
+  url_regex <- r"{\b(?:https?|ftp):\/\/[-A-Za-z0-9+&@#\/%?=~_|!:,.;]*[-A-Za-z0-9+&@#\/%=~_|]}"
+  checkmate::assert(
+    checkmate::check_directory_exists(source_conn),
+    checkmate::check_character(source_conn, pattern = url_regex)
+  )
+
+  # Determine the type of location
+  if (checkmate::test_directory_exists(source_conn)) { # source_conn is a directory
+    file_location <- file.path(source_conn, file)
+  } else if (checkmate::test_character(source_conn, pattern = url_regex)) { # source_conn is a URL
+    file_location <- paste0(source_conn, file)
+  } else {
+    stop("source_conn could not be parsed to valid directory or URL\n")
+  }
+
+  return(file_location)
+}

--- a/tests/testthat/test-DiseasystoreGoogleCovid19.R
+++ b/tests/testthat/test-DiseasystoreGoogleCovid19.R
@@ -9,7 +9,8 @@ test_that("DiseasystoreGoogleCovid19 works", {
       verbose = FALSE
     ))
 
-    expect_no_error(ds$get_feature("n_hospital"))
+    ds$available_features |>
+      purrr::walk(~ expect_no_error(ds$get_feature(.)))
   }
 
 

--- a/tests/testthat/test-feature_store_helpers.R
+++ b/tests/testthat/test-feature_store_helpers.R
@@ -64,3 +64,85 @@ test_that("get_diseasystore works", {
   expect_identical(get_diseasystore("Google COVID 19")$classname, "DiseasystoreGoogleCovid19")
 
 })
+
+
+test_that("source_conn_path works for directories", {
+
+  # Create some files to test for
+  test_dir1 <- tempdir()
+  expect_true(dir.exists(test_dir1))
+
+  test_file1 <- basename(tempfile())
+  saveRDS(mtcars, file = file.path(test_dir1, test_file1))
+
+  test_file2 <- paste0(test_file1, ".gz")
+  saveRDS(mtcars, file = file.path(test_dir1, test_file2))
+
+  test_file3 <- basename(tempfile())
+  saveRDS(mtcars, file = file.path(test_dir1, paste0(test_file3, ".gz")))
+
+  test_file4 <- basename(tempfile())
+
+  # test_file1 and test_file2 exists
+  expect_true(file.exists(file.path(test_dir1, test_file1)))
+  expect_true(file.exists(file.path(test_dir1, test_file2)))
+
+  # .. and they give paths as expected
+  expect_identical(source_conn_path(test_dir1, test_file1),
+                   file.path(test_dir1, test_file1))
+  expect_identical(source_conn_path(test_dir1, test_file2),
+                   file.path(test_dir1, test_file2))
+
+
+  # test_file3 and test_file4 does not exists
+  expect_false(file.exists(file.path(test_dir1, test_file3))) # does not exist
+  expect_false(file.exists(file.path(test_dir1, test_file4))) # does not exist
+
+  # test_file4 give errors as expected
+  expect_error(source_conn_path(test_dir1, test_file4),
+               class = "simpleError",
+               regexp = "could not be found in")
+
+  # but a test_file3.gz exists so we do get a path
+  expect_true(file.exists(file.path(test_dir1, paste0(test_file3, ".gz"))))
+  expect_identical(source_conn_path(test_dir1, test_file3),
+                   file.path(test_dir1, paste0(test_file3, ".gz")))
+
+
+
+
+  # If the files are not in the folder, all gives errors
+  test_dir2 <- stringr::str_replace(test_dir1, basename(test_dir1), tempfile(tmpdir = ""))
+
+  expect_error(source_conn_path(test_dir2, test_file1),
+               class = "simpleError",
+               regexp = "check_directory_exists")
+  expect_error(source_conn_path(test_dir2, test_file2),
+               class = "simpleError",
+               regexp = "check_directory_exists")
+  expect_error(source_conn_path(test_dir2, test_file3),
+               class = "simpleError",
+               regexp = "check_directory_exists")
+  expect_error(source_conn_path(test_dir2, test_file4),
+               class = "simpleError",
+               regexp = "check_directory_exists")
+})
+
+
+test_that("source_conn_path works for URLs", {
+
+  # Create some files to test for
+  test_url1 <- "https://test.com/"
+  test_url2 <- "https://test.com"
+
+  test_file <- basename(tempfile())
+
+
+  # Test the different combinations
+  expect_character(source_conn_path(test_url1, test_file),
+                   pattern = paste0(stringr::str_remove(test_url1, "/$"), "/", test_file))
+
+  expect_character(source_conn_path(test_url2, test_file),
+                   pattern = paste0(stringr::str_remove(test_url2, "/$"), "/", test_file))
+
+})


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
Turns out issue #60 was not fixed in all cases.
This PR fixes #60 by expanding the previous fix for the issue to all features in `DiseasystoreGoogleCovid19`

### Approach
Before, the code assumed `source_conn` was a directory across all features.
This is now changed by doing the following:

We now have the helper function `source_conn_path` which
1) Determine whether `source_conn` is either a directory or a URL
2) Creates the full file path based on the type of `source_conn` 

This helper function is now used across all features in DiseasystoreGoogleCovid19 


### Known issues
N/A


### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
