### PR TITLE
fix: ensure valid_until is a Date

### DIFF
--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -252,7 +252,7 @@ DiseasystoreBase <- R6::R6Class( # nolint: object_name_linter.
       fs_map <- self %.% fs_map
 
       # We start by copying the study_dates to the conn to ensure SQLite compatibility
-      study_dates <- data.frame(valid_from = start_date, valid_until = end_date + lubridate::days(1)) %>%
+      study_dates <- data.frame(valid_from = start_date, valid_until = as.Date(end_date + lubridate::days(1))) %>%
         dplyr::copy_to(self %.% target_conn, ., overwrite = TRUE)
 
       # Determine which features are affected by an aggregation

--- a/R/DiseasystoreGoogleCovid19.R
+++ b/R/DiseasystoreGoogleCovid19.R
@@ -141,14 +141,14 @@ google_covid_19_metric <- function(google_pattern, out_name) {
         dplyr::filter(.data$date >= as.Date("2020-01-01"),
                       {{ start_date }} <= .data$date, .data$date <= {{ end_date }}) |>
         dplyr::select("location_key", "date", tidyselect::starts_with(glue::glue("new_{google_pattern}"))) |>
-        tidyr::pivot_longer(-c("location_key", "date"),
+        tidyr::pivot_longer(!c("location_key", "date"),
                             names_to = c("tmp", "key_age_bin"),
                             names_sep = "_age_",
                             values_to = out_name,
                             values_transform = as.numeric) |>
         dplyr::select(tidyselect::all_of(c("location_key", "key_age_bin", "date", out_name))) |>
         dplyr::rename("key_location" = "location_key") |>
-        dplyr::mutate("valid_from" = .data$date, "valid_until" = .data$date + lubridate::days(1))
+        dplyr::mutate("valid_from" = .data$date, "valid_until" = as.Date(.data$date + lubridate::days(1)))
 
       return(data)
     },
@@ -299,7 +299,7 @@ google_covid_19_min_temperature_ <- function() { # nolint: object_length_linter.
         dplyr::select("key_location" = "location_key",
                       "date",
                       "min_temperature" = "minimum_temperature_celsius") |>
-        dplyr::mutate("valid_from" = .data$date, "valid_until" = .data$date + lubridate::days(1))
+        dplyr::mutate("valid_from" = .data$date, "valid_until" = as.Date(.data$date + lubridate::days(1)))
 
       return(out)
     },
@@ -323,7 +323,7 @@ google_covid_19_max_temperature_ <- function() { # nolint: object_length_linter.
         dplyr::select("key_location" = "location_key",
                       "date",
                       "max_temperature" = "maximum_temperature_celsius") |>
-        dplyr::mutate("valid_from" = .data$date, "valid_until" = .data$date + lubridate::days(1))
+        dplyr::mutate("valid_from" = .data$date, "valid_until" = as.Date(.data$date + lubridate::days(1)))
 
       return(out)
     },


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
On `PostgreSQL` back ends, `valid_until` was not always translated as a `Date` but sometimes as a `timestamp` instead

This PR fixes this.

### Approach
Wrapped all `valid_until` definitions is `as.Date()`

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
