### PR TITLE
Fix diseasyconn parsing

### DIFF
--- a/R/0_R6_utils.R
+++ b/R/0_R6_utils.R
@@ -79,7 +79,7 @@ parse_diseasyconn <- function(conn, type = "source_conn") {
   checkmate::assert(
     checkmate::check_function(conn, null.ok = TRUE),
     checkmate::check_class(conn, "DBIConnection", null.ok = TRUE),
-    checkmate::check_character(conn, len = 1, null.ok = TRUE),
+    checkmate::check_character(conn, null.ok = TRUE),
     add = coll
   )
   checkmate::assert_choice(type, c("source_conn", "target_conn"), add = coll)

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -53,13 +53,13 @@ DiseasystoreBase <- R6::R6Class( # nolint: object_name_linter.
       if (is.null(source_conn)) {
         source_conn <- diseasyoption("source_conn", self)
       }
-      private$.source_conn <- parse_diseasyconn(source_conn)
+      private$.source_conn <- parse_diseasyconn(source_conn, "source_conn")
 
 
       if (is.null(target_conn)) {
         target_conn <- diseasyoption("target_conn", self)
       }
-      private$.target_conn <- parse_diseasyconn(target_conn)
+      private$.target_conn <- parse_diseasyconn(target_conn, "target_conn")
 
 
       # Check source and target conn has been set correctly

--- a/R/DiseasystoreGoogleCovid19.R
+++ b/R/DiseasystoreGoogleCovid19.R
@@ -133,6 +133,7 @@ google_covid_19_metric <- function(google_pattern, out_name) {
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_date(start_date, lower = as.Date("2020-01-01"), add = coll)
       checkmate::assert_date(end_date,   upper = as.Date("2022-09-15"), add = coll)
+      checkmate::assert_character(source_conn, len = 1, add = coll)
       checkmate::reportAssertions(coll)
 
       # Load and parse
@@ -174,6 +175,7 @@ google_covid_19_population_ <- function() {
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_date(start_date, lower = as.Date("2020-01-01"), add = coll)
       checkmate::assert_date(end_date,   upper = as.Date("2022-09-15"), add = coll)
+      checkmate::assert_character(source_conn, len = 1, add = coll)
       checkmate::reportAssertions(coll)
 
       # Load and parse
@@ -205,6 +207,7 @@ google_covid_19_age_group_ <- function() {
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_date(start_date, lower = as.Date("2020-01-01"), add = coll)
       checkmate::assert_date(end_date,   upper = as.Date("2022-09-15"), add = coll)
+      checkmate::assert_character(source_conn, len = 1, add = coll)
       checkmate::reportAssertions(coll)
 
       # Load and parse
@@ -257,6 +260,7 @@ google_covid_19_index_ <- function() {
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_date(start_date, lower = as.Date("2020-01-01"), add = coll)
       checkmate::assert_date(end_date,   upper = as.Date("2022-09-15"), add = coll)
+      checkmate::assert_character(source_conn, len = 1, add = coll)
       checkmate::reportAssertions(coll)
 
       # Load and parse
@@ -290,6 +294,7 @@ google_covid_19_min_temperature_ <- function() { # nolint: object_length_linter.
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_date(start_date, lower = as.Date("2020-01-01"), add = coll)
       checkmate::assert_date(end_date,   upper = as.Date("2022-09-15"), add = coll)
+      checkmate::assert_character(source_conn, len = 1, add = coll)
       checkmate::reportAssertions(coll)
 
       # Load and parse
@@ -314,6 +319,7 @@ google_covid_19_max_temperature_ <- function() { # nolint: object_length_linter.
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_date(start_date, lower = as.Date("2020-01-01"), add = coll)
       checkmate::assert_date(end_date,   upper = as.Date("2022-09-15"), add = coll)
+      checkmate::assert_character(source_conn, len = 1, add = coll)
       checkmate::reportAssertions(coll)
 
       # Load and parse


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR fixes two issues with the parsing of connections (`target_conn` and `source_conn`)

1) The function `parse_diseasyconn` has a `type` argument that controls the logic it applies based on the type of connection (`target_conn` and `source_conn`)
Due to an oversight, this argument is not being used currently. This PR specifies this argument during calls to `parse_diseasyconn`

2) Checkmate checks for `source_conn` is generalised. The `source_conn` object is flexible since the various data sources are different. There is no need for the `source_conn` object to be a character of length 1 when it is a character. Indeed, in the implementation I am working on now, it is better if it is not of length 1.
The checks are therefore moved from the initialisation of the object to the specific parts of `DiseasystoreGoogleCovid19` that relies on `source_conn` having a length of 1.

### Approach
N/A

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
