### PR TITLE
Cross-backend `determine_new_ranges()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,9 @@ fields (#138).
 
 ## Minor Improvements and Fixes:
 
-* Two bugs were fixed in `$determine_new_ranges()` where existing tables were not detected (#158):
-  * when using `POSIX` `slice_ts`.
-  * on back ends that use "catalog" to structure table (DuckDB and SQL Server) (also requires SCDB > v0.4).
+* Two bugs were fixed in `$determine_new_ranges()` where existing tables were not detected:
+  * On back ends that use "catalog" to structure table (DuckDB and SQL Server) (fix also requires SCDB > v0.4) (#158).
+  * Due to `slice_ts` not being correctly matched with existing data on some backends (#172).
 
 * Long stratification expression are now properly parsed in `$key_join_features()` (#161).
 

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -636,11 +636,11 @@ DiseasystoreBase <- R6::R6Class(                                                
         self %.% target_conn,
         SCDB::id(paste(self %.% target_schema, "logs", sep = "."), self %.% target_conn)
       ) |>
+        dplyr::filter(.data$date == !!SCDB::db_timestamp(slice_ts, self %.% target_conn)) |>
         dplyr::collect() |>
         tidyr::unite("target_table", tidyselect::any_of(c("catalog", "schema", "table")), sep = ".", na.rm = TRUE) |>
         dplyr::filter(
-          .data$target_table == !!as.character(target_table),
-          strftime(.data$date, tz = "UTC") == !!strftime(slice_ts, tz = "UTC")
+          .data$target_table == !!as.character(target_table)
         )
 
       # If no logs are found, we need to compute on the entire range

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -640,7 +640,7 @@ DiseasystoreBase <- R6::R6Class(                                                
         tidyr::unite("target_table", tidyselect::any_of(c("catalog", "schema", "table")), sep = ".", na.rm = TRUE) |>
         dplyr::filter(
           .data$target_table == !!as.character(target_table),
-          strftime(.data$date) == !!strftime(slice_ts) # timezone-independent, data-type independent comparison
+          strftime(.data$date, tz = "UTC") == !!strftime(slice_ts, tz = "UTC")
         )
 
       # If no logs are found, we need to compute on the entire range

--- a/tests/testthat/test-DiseasystoreBase.R
+++ b/tests/testthat/test-DiseasystoreBase.R
@@ -132,7 +132,7 @@ test_that("$get_feature verbosity works", {
       invisible(ds$get_feature("cyl", start_date = Sys.Date(), end_date = Sys.Date())),
       type = "message"
     )
-    checkmate::expect_character(messages[[1]], pattern = "feature: cyl needs to be computed on the specified date inter.")
+    checkmate::expect_character(messages[[1]], pattern = "feature: cyl needs to be computed on the specified date int.")
     checkmate::expect_character(messages[[2]], pattern = r"{feature: cyl updated \(elapsed time}")
 
     # Second identical call should give no messages

--- a/tests/testthat/test-DiseasystoreBase.R
+++ b/tests/testthat/test-DiseasystoreBase.R
@@ -132,6 +132,11 @@ test_that("$get_feature verbosity works", {
       invisible(ds$get_feature("cyl", start_date = Sys.Date(), end_date = Sys.Date())),
       type = "message"
     )
+
+    # We keep messages from `get_feature` which starts with "feature:".
+    # Messages from other sources (duckdb or odbc) are not captured.
+    messages <- purrr::discard(messages, ~ !startsWith(., "feature:"))
+
     checkmate::expect_character(messages[[1]], pattern = "feature: cyl needs to be computed on the specified date int.")
     checkmate::expect_character(messages[[2]], pattern = r"{feature: cyl updated \(elapsed time}")
 
@@ -140,6 +145,7 @@ test_that("$get_feature verbosity works", {
       invisible(ds$get_feature("cyl", start_date = Sys.Date(), end_date = Sys.Date())),
       type = "message"
     )
+    messages <- purrr::discard(messages, ~ !startsWith(., "feature:"))
     expect_equal(messages, character(0))
 
     rm(ds)

--- a/tests/testthat/test-DiseasystoreBase.R
+++ b/tests/testthat/test-DiseasystoreBase.R
@@ -104,111 +104,124 @@ test_that("DiseasystoreBase works", {
 
 
 test_that("$get_feature verbosity works", {
-  skip_if_not_installed("RSQLite")
+  for (conn in get_test_conns()) {
 
-  # Create a dummy DiseasystoreBase with a mtcars FeatureHandler
-  DiseasystoreDummy <- R6::R6Class(                                                                                     # nolint: object_name_linter
-    classname = "DiseasystoreBase",
-    inherit = DiseasystoreBase,
-    private = list(
-      .ds_map = list("cyl" = "dummy_mtcars"),
-      dummy_mtcars = FeatureHandler$new(
-        compute = function(start_date, end_date, slice_ts, source_conn) {
-          return(dplyr::mutate(mtcars, valid_from = Sys.Date(), valid_until = as.Date(NA)))
-        }
+    # Create a dummy DiseasystoreBase with a mtcars FeatureHandler
+    DiseasystoreDummy <- R6::R6Class(                                                                                   # nolint: object_name_linter
+      classname = "DiseasystoreBase",
+      inherit = DiseasystoreBase,
+      private = list(
+        .ds_map = list("cyl" = "dummy_mtcars"),
+        dummy_mtcars = FeatureHandler$new(
+          compute = function(start_date, end_date, slice_ts, source_conn) {
+            return(dplyr::mutate(mtcars, valid_from = Sys.Date(), valid_until = as.Date(NA)))
+          }
+        )
       )
     )
-  )
 
-  # Create an instance with verbose = TRUE
-  ds <- DiseasystoreDummy$new(
-    source_conn = file.path("some", "path"),
-    target_conn = DBI::dbConnect(RSQLite::SQLite()),
-    verbose = TRUE
-  )
+    # Create an instance with verbose = TRUE
+    ds <- DiseasystoreDummy$new(
+      source_conn = file.path("some", "path"),
+      target_conn = conn,
+      verbose = TRUE
+    )
 
-  # Capture the messages from a get_feature call and compare with expectation
-  messages <- capture.output(
-    invisible(ds$get_feature("cyl", start_date = Sys.Date(), end_date = Sys.Date())),
-    type = "message"
-  )
-  checkmate::expect_character(messages[[1]], pattern = "feature: cyl needs to be computed on the specified date inter.")
-  checkmate::expect_character(messages[[2]], pattern = r"{feature: cyl updated \(elapsed time}")
+    # Capture the messages from a get_feature call and compare with expectation
+    messages <- capture.output(
+      invisible(ds$get_feature("cyl", start_date = Sys.Date(), end_date = Sys.Date())),
+      type = "message"
+    )
+    checkmate::expect_character(messages[[1]], pattern = "feature: cyl needs to be computed on the specified date inter.")
+    checkmate::expect_character(messages[[2]], pattern = r"{feature: cyl updated \(elapsed time}")
 
-  # Second identical call should give no messages
-  messages <- capture.output(
-    invisible(ds$get_feature("cyl", start_date = Sys.Date(), end_date = Sys.Date())),
-    type = "message"
-  )
-  expect_equal(messages, character(0))
+    # Second identical call should give no messages
+    messages <- capture.output(
+      invisible(ds$get_feature("cyl", start_date = Sys.Date(), end_date = Sys.Date())),
+      type = "message"
+    )
+    expect_equal(messages, character(0))
 
-  rm(ds)
+    rm(ds)
+    DBI::dbDisconnect(conn)
+  }
+
   invisible(gc())
 })
 
 
-test_that("DiseasystoreBase$determine_new_ranges works", {
-  skip_if_not_installed("RSQLite")
+test_that("DiseasystoreBase$determine_new_ranges() works", {
 
   start_date <- as.Date("2020-01-01")
   end_date   <- as.Date("2020-03-01")
-  slice_ts <- glue::glue("{Sys.Date()} 09:00:00")
 
-  conn <- DBI::dbConnect(RSQLite::SQLite())
-  ds <- DiseasystoreBase$new(source_conn = "", target_conn = conn)
+  for (conn in get_test_conns()) {
+    ds <- DiseasystoreBase$new(source_conn = "", target_conn = conn)
 
-  logs <- SCDB::create_logs_if_missing(conn = conn, log_table = paste(target_schema_1, "logs", sep = "."))
+    logs <- SCDB::create_logs_if_missing(conn = conn, log_table = paste(target_schema_1, "logs", sep = "."))
 
+    dplyr::rows_append(
+      logs,
+      data.frame(date = ds %.% slice_ts,
+                 table = "table1",
+                 message = glue::glue("ds-range: {start_date} - {end_date}"),
+                 success = TRUE,
+                 log_file = "1"),
+      copy = TRUE, in_place = TRUE
+    )
 
-  dplyr::rows_append(
-    logs,
-    data.frame(date = slice_ts,
-               table = "table1",
-               message = glue::glue("ds-range: {start_date} - {end_date}"),
-               success = TRUE,
-               log_file = "1"),
-    copy = TRUE, in_place = TRUE
-  )
+    dplyr::rows_append(
+      logs,
+      data.frame(date = ds %.% slice_ts,
+                 table = "table1",
+                 message = glue::glue("ds-range: {start_date} - {end_date}"),
+                 success = TRUE,
+                 log_file = "1"),
+      copy = TRUE, in_place = TRUE
+    )
 
-  determine_new_ranges <- ds$.__enclos_env__$private$determine_new_ranges
+    determine_new_ranges <- ds$.__enclos_env__$private$determine_new_ranges
 
-  expect_identical(
-    determine_new_ranges("table1", start_date, end_date, slice_ts),
-    tibble::tibble(start_date = as.Date(character(0)),
-                   end_date   = as.Date(character(0)))
-  )
+    expect_identical(
+      determine_new_ranges("table1", start_date, end_date, ds %.% slice_ts),
+      tibble::tibble(start_date = as.Date(character(0)),
+                     end_date   = as.Date(character(0)))
+    )
 
-  expect_identical(
-    determine_new_ranges("table2", start_date, end_date, slice_ts),
-    tibble::tibble(start_date = !!start_date,
-                   end_date   = !!end_date)
-  )
+    expect_identical(
+      determine_new_ranges("table2", start_date, end_date, ds %.% slice_ts),
+      tibble::tibble(start_date = !!start_date,
+                     end_date   = !!end_date)
+    )
 
-  expect_identical(
-    determine_new_ranges("table1", start_date, end_date + lubridate::days(5), slice_ts),
-    tibble::tibble(start_date = !!end_date + lubridate::days(1),
-                   end_date   = !!end_date + lubridate::days(5))
-  )
+    expect_identical(
+      determine_new_ranges("table1", start_date, end_date + lubridate::days(5), ds %.% slice_ts),
+      tibble::tibble(start_date = !!end_date + lubridate::days(1),
+                     end_date   = !!end_date + lubridate::days(5))
+    )
 
-  expect_identical(
-    determine_new_ranges("table1", start_date - lubridate::days(5), end_date, slice_ts),
-    tibble::tibble(start_date = !!start_date - lubridate::days(5),
-                   end_date   = !!start_date - lubridate::days(1))
-  )
+    expect_identical(
+      determine_new_ranges("table1", start_date - lubridate::days(5), end_date, ds %.% slice_ts),
+      tibble::tibble(start_date = !!start_date - lubridate::days(5),
+                     end_date   = !!start_date - lubridate::days(1))
+    )
 
-  expect_identical(
-    determine_new_ranges("table1", start_date - lubridate::days(5), end_date + lubridate::days(5), slice_ts),
-    tibble::tibble(start_date = c(!!start_date - lubridate::days(5), !!end_date + lubridate::days(1)),
-                   end_date   = c(!!start_date - lubridate::days(1), !!end_date + lubridate::days(5)))
-  )
+    expect_identical(
+      determine_new_ranges("table1", start_date - lubridate::days(5), end_date + lubridate::days(5), ds %.% slice_ts),
+      tibble::tibble(start_date = c(!!start_date - lubridate::days(5), !!end_date + lubridate::days(1)),
+                     end_date   = c(!!start_date - lubridate::days(1), !!end_date + lubridate::days(5)))
+    )
 
-  expect_identical(
-    determine_new_ranges("table1", start_date - lubridate::days(5), end_date + lubridate::days(3), slice_ts),
-    tibble::tibble(start_date = c(!!start_date - lubridate::days(5), !!end_date + lubridate::days(1)),
-                   end_date   = c(!!start_date - lubridate::days(1), !!end_date + lubridate::days(3)))
-  )
+    expect_identical(
+      determine_new_ranges("table1", start_date - lubridate::days(5), end_date + lubridate::days(3), ds %.% slice_ts),
+      tibble::tibble(start_date = c(!!start_date - lubridate::days(5), !!end_date + lubridate::days(1)),
+                     end_date   = c(!!start_date - lubridate::days(1), !!end_date + lubridate::days(3)))
+    )
 
-  rm(ds)
+    rm(ds)
+    DBI::dbDisconnect(conn)
+  }
+
   invisible(gc())
 })
 


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR seeks to fix a recurring issue of `$determine_new_ranges()` not working as intended.
(see for example https://github.com/ssi-dk/diseasystore/pull/158)

### Approach
The comparison of dates is adjusted to work across all backends by employing `SCDB::db_timestamp` and comparing
on the remote before collecting. Since the logs are written using `SCDB::db_timestamp`, the comparrison should
now always work since we are mapping `slice_ts` through the same mapping now.

The tests for `determine_new_ranges()` and `get_feature()` in `DiseasystoreBase` are now done across 
all backends instead of just `SQLite`. This helps reveal issues in the implementation.

The test for `get_feature()` makes two consecutive calls to `get_feature()` to check that the feature is not recomputed in the second call. If the feature is re-computed, this is typically due to bugs in `determine_new_ranges`.

This test was updated to remove messages not from diseasystore. 
When connecting to a DuckDB database, the R driver writes a (meaningless) message related to S3 dispatch. 
Similarly, when connected to a SQL Sever database the R driver likes to spam the console with messages about "Created temporary table ..." which we also do not care about (and which we cannot easily disable?)

Regardless, by filtering these out the test now works as expected. 
A message is given in the first call that the feature needs to be computed, but not in the second call since it is already computed and the `determine_new_ranges()` function detects that it has been computed.

### Known issues
N/A


### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
