### PR TITLE
Improve detection of exiting stratifications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,10 @@ fields (#138).
 
 * When creating your own `diseasystore` it is now easier to inherit from the base module (#189).
 
+* Warnings about existing stratifications now only appear if the requested stratification contains a named expression
+  matching an existing stratification. Simply requesting the stratification from the feature store will no longer
+  produce a warning (#190).
+
 ## Testing:
 
 * `test_diseasystore()` now also checks that the `FeatureHandler`s return data directly:


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent

The detection of collision between existing stratifications and requested stratifications has been improved to only trigger
warnings if the requested stratification does a computation (e.g. rlang::quos(age_group = .data$age_group  > '50').

If this computation has a output name that matches an existing stratification, there may be inconsistencies. In this case,
the output name is "age_group" but there already exists the "age_group" stratification, and a warning should be thrown.

Just requesting the "age_group" stratification should not produce a warning (e.g. rlang::quos(age_group)).

```
# Assuming a diseasystore with the stratification "age_group"

# Before, both cases produce a warning:
ds$key_join_features(observable, stratification = rlang::quos(age_group)) # Produces warning
ds$key_join_features(observable, stratification = rlang::quos(age_group = 2)) # Produces warning

# After, only the latter case produces a warning
ds$key_join_features(observable, stratification = rlang::quos(age_group))
ds$key_join_features(observable, stratification = rlang::quos(age_group = 2)) # Produces warning
```

### Approach
The detection of collision when stratifying is restricted to stratifications with computations

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
