### PR TITLE
Suppress namespace linter warnings for simulist_data

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,5 @@ man-roxygen
 ^CRAN-SUBMISSION$
 ^pak.lock
 ^data-raw$
+^pkg-build$
+

--- a/data-raw/simulist_data.R
+++ b/data-raw/simulist_data.R
@@ -14,7 +14,7 @@ if (rlang::is_installed("simulist") && rlang::is_installed("usethis")) {
   # Generate the full simulist
   set.seed(1)
 
-  simulist_data <- simulist::sim_linelist(
+  simulist_data <- simulist::sim_linelist(                                                                              # nolint: namespace_linter. simulist is not installed by default
     contact_distribution = function(x) stats::dpois(x = x, lambda = 2),
     infectious_period = function(x) stats::rlnorm(n = x, meanlog = 2, sdlog = 0.5),
     prob_infection = 0.75,
@@ -29,7 +29,7 @@ if (rlang::is_installed("simulist") && rlang::is_installed("usethis")) {
     anonymise = TRUE,
     population_age = c(1, 90),
     case_type_probs = c(suspected = 0.2, probable = 0.3, confirmed = 0.5),
-    config = simulist::create_config()
+    config = simulist::create_config()                                                                                  # nolint: namespace_linter. simulist is not installed by default
   )
 
   # Convert to tibble


### PR DESCRIPTION
### Intent
This PR suppresses the lints about missing simulsit package

As of #185 simulist is no longer a dependency, so the `namespace_linter` will complain about the `data-raw/simulist_data.R` file.

### Approach
`nolint` statements added

### Known issues
~~The R v3.5.0 check complains -- fixed in https://github.com/ssi-dk/diseasystore/pull/195~~


### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR