### PR TITLE
Allow feature independent stratifications in `$key_join_features`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # diseasystore (development version)
 
+## Breaking change
+
+* `DiseasystoreBase$key_join_features()` no longer accept character stratifications -- must use `rlang::quos()` (#203).
+
 ## Minor Improvements and Fixes
 
 * The `$observable_regex` field is added, which shows the regex that demarcates observables from stratifications (#204).

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The `$observable_regex` field is added, which shows the regex that demarcates observables from stratifications (#204).
 
+* In `DiseasystoreBase$key_join_features()`, stratifications no longer need to do computation on other features (#203).
+
 
 # diseasystore 0.3.0
 

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -351,14 +351,6 @@ DiseasystoreBase <- R6::R6Class(                                                
           unlist() |>
           unique()
 
-        # Report if stratification not found
-        if (is.null(stratification_features)) {
-          err <- glue::glue("Stratification variable not found. ",
-                            "Available stratification variables are: ",
-                            "{toString(self$available_stratifications)}")
-          stop(err, call. = FALSE)
-        }
-
         # Determine the name of the columns created by the stratifications
         stratification_names <- stratification |>
           purrr::map(rlang::as_label) |>

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -281,11 +281,7 @@ DiseasystoreBase <- R6::R6Class(                                                
 
       coll <- checkmate::makeAssertCollection()
       checkmate::assert_choice(observable, self$available_observables, add = coll)
-      checkmate::assert(
-        checkmate::check_list(stratification, types = "character", null.ok = TRUE),
-        checkmate::check_multi_class(stratification, c("character", "quosure", "quosures"), null.ok = TRUE),
-        add = coll
-      )
+      checkmate::assert_multi_class(stratification, c("quosure", "quosures"), null.ok = TRUE, add = coll)
       checkmate::assert_date(start_date, add = coll)
       checkmate::assert_date(end_date, add = coll)
       checkmate::reportAssertions(coll)

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -441,8 +441,8 @@ DiseasystoreBase <- R6::R6Class(                                                
 
       if (!is.null(stratification)) {
         all_combinations <- out |>
-          dplyr::ungroup() |>
-          dplyr::distinct(!!!stratification) |>
+          dplyr::select(dplyr::all_of(stratification_names)) |>
+          dplyr::distinct() |>
           dplyr::cross_join(all_dates, copy = TRUE) |>
           dplyr::compute()
         SCDB::defer_db_cleanup(all_combinations)

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -416,7 +416,7 @@ DiseasystoreBase <- R6::R6Class(                                                
             "Available stratification variables are: ",
             "{toString(self$available_stratifications)}"
           )
-          stop(error_msg)
+          stop(error_msg, call. = FALSE)
         }
       )
 

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -516,6 +516,31 @@ test_diseasystore <- function(
   })
 
 
+  testthat::test_that(glue::glue("{diseasystore_class} can key_join with feature-independent stratification"), {
+    testthat::skip_if_not(local)
+
+    for (conn in conn_generator(skip_backends)) {
+
+      # Initialise without start_date and end_date
+      ds <- testthat::expect_no_error(diseasystore_generator$new(verbose = FALSE, target_conn = conn, ...))
+
+      # Check we can aggregate without feature-independent stratifications
+      output <- ds$key_join_features(
+        observable = ds$available_observables[[1]],
+        stratification = rlang::quos(string = "test", number = 2),
+        test_start_date,
+        test_end_date
+      )
+
+      expect_identical(unique(dplyr::pull(output, "string")), "test")
+      expect_identical(unique(dplyr::pull(output, "number")), 2)
+
+      rm(ds)
+      invisible(gc())
+    }
+  })
+
+
   testthat::test_that(glue::glue("{diseasystore_class} key_join fails gracefully"), {
     testthat::skip_if_not(local)
 

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -526,7 +526,7 @@ test_diseasystore <- function(
 
       if (length(ds$available_observables) > 0) {
 
-        # Check we can aggregate without feature-independent stratifications
+        # Check we can aggregate with feature-independent stratifications
         output <- ds$key_join_features(
           observable = ds$available_observables[[1]],
           stratification = rlang::quos(string = "test", number = 2),

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -524,16 +524,19 @@ test_diseasystore <- function(
       # Initialise without start_date and end_date
       ds <- testthat::expect_no_error(diseasystore_generator$new(verbose = FALSE, target_conn = conn, ...))
 
-      # Check we can aggregate without feature-independent stratifications
-      output <- ds$key_join_features(
-        observable = ds$available_observables[[1]],
-        stratification = rlang::quos(string = "test", number = 2),
-        test_start_date,
-        test_end_date
-      )
+      if (length(ds$available_observables) > 0) {
 
-      expect_identical(unique(dplyr::pull(output, "string")), "test")
-      expect_identical(unique(dplyr::pull(output, "number")), 2)
+        # Check we can aggregate without feature-independent stratifications
+        output <- ds$key_join_features(
+          observable = ds$available_observables[[1]],
+          stratification = rlang::quos(string = "test", number = 2),
+          test_start_date,
+          test_end_date
+        )
+
+        expect_identical(unique(dplyr::pull(output, "string")), "test")
+        expect_identical(unique(dplyr::pull(output, "number")), 2)
+      }
 
       rm(ds)
       invisible(gc())

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -534,8 +534,8 @@ test_diseasystore <- function(
           test_end_date
         )
 
-        expect_identical(unique(dplyr::pull(output, "string")), "test")
-        expect_identical(unique(dplyr::pull(output, "number")), 2)
+        testthat::expect_identical(unique(dplyr::pull(output, "string")), "test")
+        testthat::expect_identical(unique(dplyr::pull(output, "number")), 2)
       }
 
       rm(ds)

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -562,7 +562,7 @@ test_diseasystore <- function(
           output <- tryCatch({
             ds$key_join_features(
               observable = as.character(observable),
-              stratification = as.character(stratification), # Output of expand.grid is a factor.
+              stratification = eval(parse(text = glue::glue("rlang::quos({stratification})"))),
               start_date = test_start_date,
               end_date = test_end_date
             )

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -539,12 +539,7 @@ test_diseasystore <- function(
               end_date = test_end_date
             )
           }, error = function(e) {
-            checkmate::expect_character(
-              e$message,
-              pattern = glue::glue("Stratification variable not found. ",
-                                   "Available stratification variables are: ",
-                                   "{toString(ds$available_stratifications)}")
-            )
+            checkmate::expect_character(e$message, pattern = "Stratification could not be computed")
             return(NULL)
           })
 
@@ -568,12 +563,7 @@ test_diseasystore <- function(
               end_date = test_end_date
             )
           }, error = function(e) {
-            checkmate::expect_character(
-              e$message,
-              pattern = glue::glue("Stratification variable not found. ",
-                                   "Available stratification variables are: ",
-                                   "{toString(ds$available_stratifications)}")
-            )
+            checkmate::expect_character(e$message, pattern = "Stratification could not be computed")
             return(NULL)
           })
 

--- a/tests/testthat/test-DiseasystoreBase.R
+++ b/tests/testthat/test-DiseasystoreBase.R
@@ -279,7 +279,7 @@ test_that("$key_join_features works with non-computing stratifications", {
   # Create new instance
   ds <- DiseasystoreDummy$new(target_conn = DBI::dbConnect(RSQLite::SQLite()), verbose = FALSE)
 
-  # Check that we can join the features even if stratification does no computation on features
+  # Check that we can join the features even if stratification does not compute on features
   expect_no_error(
     ds$key_join_features(
       observable = "n_cyl",


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
This PR removes a error message that blocks a specific use-case needed for `diseasy`.

Specifically, if you have stratifications like
```r
rlang::quos(age_group = "0+")
```
then, `diseasystore` will currently throw an error since no features are included in the computation.

This PR removes this error


### Approach
We now try to perform the grouping at the stratification level and then check if an error is produced.

Also, I had to fully deprecate non-`rlang::quos()` stratifications. 
The documentation has specified to use `rlang::quos()` for a while but we still allowed it -- that is no longer the case

### Known issues
N/A

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
