### PR TITLE
Fix date comparison in diseasystore tests

### DIFF
--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -457,8 +457,8 @@ test_diseasystore <- function(
   # Helper function that checks the output of key_joins
   key_join_features_tester <- function(output, start_date, end_date) {
     # The output dates should match start and end date
-    testthat::expect_identical(min(output$date), start_date)
-    testthat::expect_identical(max(output$date), end_date)
+    testthat::expect_equal(min(output$date), start_date)                                                                # nolint: expect_identical_linter. R 4.5 makes dates more confusing than it already is
+    testthat::expect_equal(max(output$date), end_date)                                                                  # nolint: expect_identical_linter.
   }
 
 


### PR DESCRIPTION
<!-- Thanks for contributing!

Before creating your pull request, please read this comment in its entirety.
This will help with reviewing the changes and hopefully merge your changes into
the repository as smoothly as possible.


# Pull request title

Your title should be short yet exhaustive. Hopefully, this comes easily,
as pull requests should be single-topic as possible.


# Issue references
Ideally, the PR addresses an issue. If so, please reference the issue number
in the PR title and/or the body text. See also "Linking a pull request to an issue"
linked in the "Intent" section.


# Automated tests
The package supports several backends, and tests the coverage of these.
If the pull request modifies code which is used by multiple backends, please
test the changes locally before submitting a pull request if possible.
-->

### Intent
The development version of R now no longer supports the `idenitcal()` operation on two dates as the R developers has decided that they like data-types even less than they already do.

### Approach
`expect_identical()` has been swapped with `expect_eqaul()` when comparing dates

### Known issues
R-devel

### Checklist

* [x] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
