### PR TITLE
Fix misspecified `observable_regex` in `DiseasystoreEcdcRespiratoryViruses`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * Private method `DiseasystoreBase$determine_missing_ranges()` made public (#224).
   Previously called `$determine_new_ranges()`.
 
+## Minor Improvements and Fixes
+
+* Observables are now listed in `DiseasystoreEcdcRespiratoryViruses` (#227).
+
 
 # diseasystore 0.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 
 * Observables are now listed in `DiseasystoreEcdcRespiratoryViruses` (#227).
 
+## Documentation
+
+* Restrictions on automatic data-coupling is now better described (#227)
+
 
 # diseasystore 0.3.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # diseasystore (development version)
 
+## Minor Improvements and Fixes
+
+* Observables are now listed in `DiseasystoreEcdcRespiratoryViruses` (#227).
+
+
 # diseasystore 0.3.3
 
 ## New Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@
 
 * Compatibility with `duckdb v1.5.0` (#235).
 
+## Documentation
+
+* Restrictions on automatic data-coupling is now better described (#227)
+
 
 # diseasystore 0.3.2
 

--- a/R/1_aggregators.R
+++ b/R/1_aggregators.R
@@ -40,39 +40,63 @@
 #'   key_join_count(data, "mpg")  # nrow(mtcars)
 #' @export
 key_join_sum <- function(.data, feature) {
-  return(dplyr::summarise(.data,
-                          dplyr::across(.cols = tidyselect::all_of(feature),
-                                        .fns = list(n = ~ sum(as.numeric(.), na.rm = TRUE)),
-                                        .names = "{.fn}"),
-                          .groups = "drop"))
+  return(
+    dplyr::summarise(
+      .data,
+      dplyr::across(
+        .cols = tidyselect::all_of(feature),
+        .fns = list(value = ~ sum(as.numeric(.), na.rm = TRUE)),
+        .names = "{.fn}"
+      ),
+      .groups = "drop"
+    )
+  )
 }
 
 #' @rdname aggregators
 #' @export
 key_join_max <- function(.data, feature) {
-  return(dplyr::summarise(.data,
-                          dplyr::across(.cols = tidyselect::all_of(feature),
-                                        .fns = list(n = ~ max(as.numeric(.), na.rm = TRUE)),
-                                        .names = "{.fn}"),
-                          .groups = "drop"))
+  return(
+    dplyr::summarise(
+      .data,
+      dplyr::across(
+        .cols = tidyselect::all_of(feature),
+        .fns = list(value = ~ max(as.numeric(.), na.rm = TRUE)),
+        .names = "{.fn}"
+      ),
+      .groups = "drop"
+    )
+  )
 }
 
 #' @rdname aggregators
 #' @export
 key_join_min <- function(.data, feature) {
-  return(dplyr::summarise(.data,
-                          dplyr::across(.cols = tidyselect::all_of(feature),
-                                        .fns = list(n = ~ min(as.numeric(.), na.rm = TRUE)),
-                                        .names = "{.fn}"),
-                          .groups = "drop"))
+  return(
+    dplyr::summarise(
+      .data,
+      dplyr::across(
+        .cols = tidyselect::all_of(feature),
+        .fns = list(value = ~ min(as.numeric(.), na.rm = TRUE)),
+        .names = "{.fn}"
+      ),
+      .groups = "drop"
+    )
+  )
 }
 
 #' @rdname aggregators
 #' @export
 key_join_count <- function(.data, feature) {
-  return(dplyr::summarise(.data,
-                          dplyr::across(.cols = purrr::pluck(tidyselect::starts_with("key"), 1),
-                                        .fns = list(n = ~ dplyr::n()),
-                                        .names = "{.fn}"),
-                          .groups = "drop"))
+  return(
+    dplyr::summarise(
+      .data,
+      dplyr::across(
+        .cols = purrr::pluck(tidyselect::starts_with("key"), 1),
+        .fns = list(value = ~ dplyr::n()),
+        .names = "{.fn}"
+      ),
+      .groups = "drop"
+    )
+  )
 }

--- a/R/1_aggregators.R
+++ b/R/1_aggregators.R
@@ -1,7 +1,28 @@
 # We have to wrap the summarise here, since across does stupid caller env blocking
 
 
+#' @title title
 #' Feature aggregators
+#'
+#' @description
+#' When designing a `diseasystore` (see `vignette("extending-diseasystore")`), each feature must specify
+#' how that data should be summarised when joined with other data.
+#'
+#' The automatic coupling and aggregation is essentially a three part process:
+#' First, data for the observable is joined with data required to form the stratifications.
+#' Next, the combined data is grouped at the level of stratification requested.
+#' Finally, the data is summarised in each group to form a single value for the group.
+#'
+#' Below, we provide a set of simple function that perform this final summarisation step.
+#'
+#' For semi-aggregated data, a typical key_join aggregator is the `key_join_sum()` which just adds the observations
+#' across the group
+#'
+#' In some cases, such as if the observable is the "maximum temperature" the relevant aggregator would be the
+#' `key_join_max()` aggregator which takes the max across the group.
+#'
+#' When working with individual level data, the observables often consists of a record per individual and to
+#' summarise the data we instead need the `key_join_count()` aggregator to get the size of the group.
 #'
 #' @name aggregators
 #' @param .data `r rd_.data()`

--- a/R/2_FeatureHandler.R
+++ b/R/2_FeatureHandler.R
@@ -96,9 +96,9 @@ FeatureHandler <- R6::R6Class(                                                  
       }
 
       if (is.null(key_join)) {
-        args  <- append(args, c("key_join" = \(...) stop("key_join not configured!", call. = FALSE)))
+        args  <- append(args, c("key_join" = NULL))
       } else {
-        checkmate::assert_function(key_join, args = c(".data", "feature"))
+        checkmate::assert_function(key_join, args = c(".data", "feature"), null.ok = TRUE)
       }
 
       # Set the functions of the FeatureHandler

--- a/R/DiseasystoreBase.R
+++ b/R/DiseasystoreBase.R
@@ -310,6 +310,13 @@ DiseasystoreBase <- R6::R6Class(                                                
       observable_data <- self$get_feature(observable, start_date, end_date)
       SCDB::defer_db_cleanup(observable_data)
 
+      # The automatic aggregation of key_join_features only work if observable is countable
+      # In the naming convention, this is indicated by the column being named "n".
+      # Therefore, if no "n" column exists, we interpret the data as non-countable
+      if (!("n" %in% colnames(observable_data))) {
+        pkgcond::pkg_error("Automatic aggregation with `key_join_filter()` only works for countable observables!")
+      }
+
       observable_data <- observable_data |>
         dplyr::cross_join(study_dates, suffix = c("", ".d")) |>
         dplyr::mutate(

--- a/R/DiseasystoreEcdcRespiratoryViruses.R
+++ b/R/DiseasystoreEcdcRespiratoryViruses.R
@@ -82,8 +82,7 @@ DiseasystoreEcdcRespiratoryViruses <- R6::R6Class(                              
           dplyr::filter({{ start_date }} < .data$valid_until, .data$valid_from <= {{ end_date }})
 
         return(out)
-      },
-      key_join = \(.data, feature) .data
+      }
     ),
 
 

--- a/R/DiseasystoreEcdcRespiratoryViruses.R
+++ b/R/DiseasystoreEcdcRespiratoryViruses.R
@@ -42,6 +42,7 @@ DiseasystoreEcdcRespiratoryViruses <- R6::R6Class(                              
       "age_group"      = "ecdc_respitory_viruses_iliari_rates"
     ),
     .label = "ECDC Respitory Viruses",
+    .observables_regex = r"{\w+_rates}",
 
     .min_start_date = as.Date("2014-09-29"),
     .max_end_date = NULL, # Data source is still actively updated

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -548,6 +548,11 @@ test_diseasystore <- function(
   # To do so, we run $key_join_features() with stratfication = NULL to see if the internal error is raised
 
   conns <- conn_generator(skip_backends)
+  if (length(conns) == 0) {
+    # Diseasystore has no testable connections in this workflow
+    return()
+  }
+
   ds <- diseasystore_generator$new(verbose = FALSE, target_conn = conns[[1]], ...)
   observables <- ds$available_observables
   non_aggregatable_observables <- character(0)

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -536,9 +536,11 @@ test_diseasystore <- function(
   # For the most part, the diseasystores should be able to automatically aggregate a feature using.
   # $key_join_features().
   #
-  # The requirement is that the observable is countable (see vignette("extending-diseasystore")),
-  # which most often is the case.
-  # However, if the observable is not countable (such as the rate of a disease), a error will be raised internally
+  # The requirement is that the observable has a corresponding "key_join" function
+  # (see vignette("extending-diseasystore")) which most often is the case.
+
+  # However, if the observable cannot be aggregated simply (such as the rate of a disease), no "key_join" function
+  # can be used and an error will be raised internally
 
   # Since the following tests verify the output of $key_join_features(), we need to determine which observables
   # the tests should run on
@@ -548,10 +550,10 @@ test_diseasystore <- function(
   conns <- conn_generator(skip_backends)
   ds <- diseasystore_generator$new(verbose = FALSE, target_conn = conns[[1]], ...)
   observables <- ds$available_observables
-  non_countable_observables <- character(0)
+  non_aggregatable_observables <- character(0)
 
   for (observable in observables) {
-    non_countable_observables <- tryCatch(
+    non_aggregatable_observables <- tryCatch(
       ds$key_join_features(observable = observable, stratification = NULL, test_start_date, test_end_date),
 
       error = function(e) {
@@ -561,8 +563,8 @@ test_diseasystore <- function(
             "Automatic aggregation with `key_join_filter()` only works for features where \"key_join\" is defined!"
           )
         ) {
-          # Mark down the non-countable observable
-          return(c(non_countable_observables, observable))
+          # Mark down the non-aggregatable observable
+          return(c(non_aggregatable_observables, observable))
         }
       }
     )
@@ -573,8 +575,8 @@ test_diseasystore <- function(
   rm(ds)
   invisible(gc())
 
-  # Filter out the non-countable observables for the remaining tests
-  countable_observables <- setdiff(observables, non_countable_observables)
+  # Filter out the non-aggregatable observables for the remaining tests
+  aggregatable_observables <- setdiff(observables, non_aggregatable_observables)
 
 
   testthat::test_that(glue::glue("{diseasystore_class} can key_join features"), {
@@ -586,14 +588,14 @@ test_diseasystore <- function(
       ds <- testthat::expect_no_error(diseasystore_generator$new(verbose = FALSE, target_conn = conn, ...))
 
       # First check we can aggregate without a stratification
-      for (observable in countable_observables) {
+      for (observable in aggregatable_observables) {
         testthat::expect_no_error(
           ds$key_join_features(observable = observable, stratification = NULL, test_start_date, test_end_date)
         )
       }
 
       # Then test combinations with non-NULL stratifications
-      expand.grid(observable     = countable_observables,
+      expand.grid(observable     = aggregatable_observables,
                   stratification = ds$available_stratifications) |>
         purrr::pwalk(\(observable, stratification) {
           # This code may fail (gracefully) in some cases. These we catch here
@@ -639,11 +641,11 @@ test_diseasystore <- function(
       # Initialise without start_date and end_date
       ds <- testthat::expect_no_error(diseasystore_generator$new(verbose = FALSE, target_conn = conn, ...))
 
-      if (length(countable_observables) > 0) {
+      if (length(aggregatable_observables) > 0) {
 
         # Check we can aggregate with feature-independent stratifications
         output <- ds$key_join_features(
-          observable = countable_observables[[1]],
+          observable = aggregatable_observables[[1]],
           stratification = rlang::quos(string = "test", number = 2),
           test_start_date,
           test_end_date
@@ -673,7 +675,7 @@ test_diseasystore <- function(
       # Attempt to perform the possible key_joins
 
       # Test key_join with malformed inputs
-      expand.grid(observable     = countable_observables,
+      expand.grid(observable     = aggregatable_observables,
                   stratification = "non_existent_stratification") |>
         purrr::pwalk(\(observable, stratification) {
           # This code may fail (gracefully) in some cases. These we catch here
@@ -697,7 +699,7 @@ test_diseasystore <- function(
         })
 
 
-      expand.grid(observable     = countable_observables,
+      expand.grid(observable     = aggregatable_observables,
                   stratification = "test = non_existent_stratification") |>
         purrr::pwalk(\(observable, stratification) {
           # This code may fail (gracefully) in some cases. These we catch here

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -190,7 +190,7 @@ test_diseasystore <- function(
       checkmate::expect_class(.x, "FeatureHandler")
       checkmate::expect_function(.x %.% compute)
       checkmate::expect_function(.x %.% get)
-      checkmate::expect_function(.x %.% key_join)
+      checkmate::expect_function(.x %.% key_join, null.ok = TRUE)
     })
 
     # Check that the min and max dates have been set

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -285,6 +285,15 @@ test_diseasystore <- function(
   })
 
 
+  testthat::test_that(glue::glue("{diseasystore_class} has observables"), {
+    for (conn in conn_generator(skip_backends)) {
+      ds <- testthat::expect_no_error(diseasystore_generator$new(verbose = FALSE, target_conn = conn, ...))
+
+      checkmate::expect_character(ds$available_observables, min.len = 1)
+    }
+  })
+
+
   # Set a test_end_date for the test
   test_end_date <- test_start_date + lubridate::days(4)
 

--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -558,7 +558,7 @@ test_diseasystore <- function(
         if (
           identical(
             e$message,
-            "Automatic aggregation with `key_join_filter()` only works for countable observables!"
+            "Automatic aggregation with `key_join_filter()` only works for features where \"key_join\" is defined!"
           )
         ) {
           # Mark down the non-countable observable

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -63,6 +63,7 @@ diseasy
 Diseasy's
 diseasystore
 DiseasystoreBase
+DiseasystoreEcdcRespiratoryViruses
 DiseasystoreGoogleCovid
 diseasystores
 DiseasyActivity

--- a/man/aggregators.Rd
+++ b/man/aggregators.Rd
@@ -6,7 +6,8 @@
 \alias{key_join_max}
 \alias{key_join_min}
 \alias{key_join_count}
-\title{Feature aggregators}
+\title{title
+Feature aggregators}
 \usage{
 key_join_sum(.data, feature)
 
@@ -26,7 +27,24 @@ Name of the feature to perform the aggregation over}
 A dplyr::summarise to aggregate the features together using the given function (sum/max/min/count)
 }
 \description{
-Feature aggregators
+When designing a \code{diseasystore} (see \code{vignette("extending-diseasystore")}), each feature must specify
+how that data should be summarised when joined with other data.
+
+The automatic coupling and aggregation is essentially a three part process:
+First, data for the observable is joined with data required to form the stratifications.
+Next, the combined data is grouped at the level of stratification requested.
+Finally, the data is summarised in each group to form a single value for the group.
+
+Below, we provide a set of simple function that perform this final summarisation step.
+
+For semi-aggregated data, a typical key_join aggregator is the \code{key_join_sum()} which just adds the observations
+across the group
+
+In some cases, such as if the observable is the "maximum temperature" the relevant aggregator would be the
+\code{key_join_max()} aggregator which takes the max across the group.
+
+When working with individual level data, the observables often consists of a record per individual and to
+summarise the data we instead need the \code{key_join_count()} aggregator to get the size of the group.
 }
 \examples{
   # Primarily used within the framework but can be used individually:

--- a/pak.lock
+++ b/pak.lock
@@ -196,7 +196,7 @@
     },
     {
       "package": "gert",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "binary": true
     },
     {
@@ -431,7 +431,7 @@
     },
     {
       "package": "purrr",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "binary": true
     },
     {
@@ -461,7 +461,7 @@
     },
     {
       "package": "Rcpp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "binary": true
     },
     {
@@ -481,7 +481,7 @@
     },
     {
       "package": "rlang",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "binary": true
     },
     {
@@ -581,7 +581,7 @@
     },
     {
       "package": "testthat",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "binary": true
     },
     {
@@ -591,7 +591,7 @@
     },
     {
       "package": "tibble",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "binary": true
     },
     {

--- a/pak.lock
+++ b/pak.lock
@@ -111,7 +111,7 @@
     },
     {
       "package": "dbplyr",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "binary": true
     },
     {
@@ -151,7 +151,7 @@
     },
     {
       "package": "duckdb",
-      "version": "1.5.2",
+      "version": "1.5.4",
       "binary": true
     },
     {
@@ -396,7 +396,7 @@
     },
     {
       "package": "pkgload",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "binary": true
     },
     {
@@ -501,7 +501,7 @@
     },
     {
       "package": "RSQLite",
-      "version": "3.53.1",
+      "version": "3.53.2",
       "binary": true
     },
     {
@@ -531,7 +531,7 @@
     },
     {
       "package": "SCDB",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "binary": true
     },
     {
@@ -541,7 +541,7 @@
     },
     {
       "package": "shiny",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "binary": true
     },
     {
@@ -606,7 +606,7 @@
     },
     {
       "package": "tinytex",
-      "version": "0.59",
+      "version": "0.60",
       "binary": true
     },
     {
@@ -656,17 +656,17 @@
     },
     {
       "package": "withr",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "binary": true
     },
     {
       "package": "xfun",
-      "version": "0.58",
+      "version": "0.59",
       "binary": true
     },
     {
       "package": "xml2",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "binary": true
     },
     {

--- a/tests/testthat/test-FeatureHandler.R
+++ b/tests/testthat/test-FeatureHandler.R
@@ -7,21 +7,21 @@ test_that("FeatureHandler initializes with correctly formed arguments", {
   checkmate::expect_class(fh, "FeatureHandler")
   checkmate::assert_function(fh$compute,  args = "...")
   checkmate::assert_function(fh$get,      args = c("target_table", "slice_ts", "target_conn"))
-  checkmate::assert_function(fh$key_join, args = "...")
+  checkmate::assert_function(fh$key_join, args = "...", null.ok = TRUE)
   rm(fh)
 
   # 2) Correctly formed compute function
   fh <- expect_no_error(FeatureHandler$new(compute = \(start_date, end_date, slice_ts, source_conn, ...) 1))
   checkmate::assert_function(fh$compute,  args = c("start_date", "end_date", "slice_ts", "source_conn", "..."))
   checkmate::assert_function(fh$get,      args = c("target_table", "slice_ts", "target_conn"))
-  checkmate::assert_function(fh$key_join, args = "...")
+  checkmate::assert_function(fh$key_join, args = "...", null.ok = TRUE)
   rm(fh)
 
   # 3) Correctly formed get function
   fh <- expect_no_error(FeatureHandler$new(get = \(target_table, slice_ts, target_conn) 1))
   checkmate::assert_function(fh$compute,  args = "...")
   checkmate::assert_function(fh$get,      args = c("target_table", "slice_ts", "target_conn"))
-  checkmate::assert_function(fh$key_join, args = "...")
+  checkmate::assert_function(fh$key_join, args = "...", null.ok = TRUE)
   rm(fh)
 
   # 4) Correctly formed key_join function

--- a/tests/testthat/test-aggregators.R
+++ b/tests/testthat/test-aggregators.R
@@ -1,31 +1,45 @@
 test_that("key_join_sum works", {
-  expect_identical(mtcars |> key_join_sum("cyl") |> dplyr::pull("n"),
-                   mtcars |> dplyr::pull("cyl") |> sum())
+  expect_identical(
+    mtcars |> key_join_sum("cyl") |> dplyr::pull("value"),
+    mtcars |> dplyr::pull("cyl") |> sum()
+  )
 
-  expect_identical(mtcars |> key_join_sum("vs") |> dplyr::pull("n"),
-                   mtcars |> dplyr::pull("vs") |> sum())
+  expect_identical(
+    mtcars |> key_join_sum("vs") |> dplyr::pull("value"),
+    mtcars |> dplyr::pull("vs") |> sum()
+  )
 })
 
 
 test_that("key_join_max works", {
-  expect_identical(mtcars |> key_join_max("cyl") |> dplyr::pull("n"),
-                   mtcars |> dplyr::pull("cyl") |> max())
+  expect_identical(
+    mtcars |> key_join_max("cyl") |> dplyr::pull("value"),
+    mtcars |> dplyr::pull("cyl") |> max()
+  )
 
-  expect_identical(mtcars |> key_join_max("vs") |> dplyr::pull("n"),
-                   mtcars |> dplyr::pull("vs") |> max())
+  expect_identical(
+    mtcars |> key_join_max("vs") |> dplyr::pull("value"),
+    mtcars |> dplyr::pull("vs") |> max()
+  )
 })
 
 
 test_that("key_join_min works", {
-  expect_identical(mtcars |> key_join_min("cyl") |> dplyr::pull("n"),
-                   mtcars |> dplyr::pull("cyl") |> min())
+  expect_identical(
+    mtcars |> key_join_min("cyl") |> dplyr::pull("value"),
+    mtcars |> dplyr::pull("cyl") |> min()
+  )
 
-  expect_identical(mtcars |> key_join_min("vs") |> dplyr::pull("n"),
-                   mtcars |> dplyr::pull("vs") |> min())
+  expect_identical(
+    mtcars |> key_join_min("vs") |> dplyr::pull("value"),
+    mtcars |> dplyr::pull("vs") |> min()
+  )
 })
 
 
 test_that("key_join_count works", {
-  expect_identical(mtcars |> dplyr::rename("key_cyl" = "cyl") |> key_join_count() |> dplyr::pull("n"),
-                   nrow(mtcars))
+  expect_identical(
+    mtcars |> dplyr::rename("key_cyl" = "cyl") |> key_join_count() |> dplyr::pull("value"),
+    nrow(mtcars)
+  )
 })

--- a/vignettes/extending-diseasystore.Rmd
+++ b/vignettes/extending-diseasystore.Rmd
@@ -61,9 +61,11 @@ This coupling requires common "key_\*" columns between the features.
 Any feature in a `diseasystore` therefore must have at least one "key_\*" column.
 By convention, we place these column as the first columns of the table.
 
-Another limitation of the automatic aggregation, is that the observable to aggregate must be countable
-(e.g. it cannot be a rate).
-In practice, any observable that can meaningfully use the `?aggregators` to summarise the data fulfils this requirement.
+Some features will not be meaningfully aggregated automatically e.g. the incidence of a disease must use information
+about the population size to aggregate meaningfully.
+
+In practice, any observable that can meaningfully use the `?aggregators` to summarise the data can automatically
+be coupled.
 
 
 ## Features

--- a/vignettes/extending-diseasystore.Rmd
+++ b/vignettes/extending-diseasystore.Rmd
@@ -61,6 +61,11 @@ This coupling requires common "key_\*" columns between the features.
 Any feature in a `diseasystore` therefore must have at least one "key_\*" column.
 By convention, we place these column as the first columns of the table.
 
+Another limitation of the automatic aggregation, is that the observable to aggregate must be countable
+(e.g. it cannot be a rate).
+In practice, any observable that can meaningfully use the `?aggregators` to summarise the data fulfils this requirement.
+
+
 ## Features
 Finally, we come to the main data of the `diseasystore`, namely the features.
 First, a reminder that "feature" here comes from machine learning and is any individual piece of information.
@@ -159,7 +164,7 @@ In the event, that you need to create your own aggregator the arguments are as f
 * `feature` is the name of the feature(s) to aggregate.
 
 Your aggregator should return a `dplyr::summarise()` call that operates on all columns specified in the `feature`
-argument.
+argument and should return the result in a column named "n".
 
 
 ## Putting it all together

--- a/vignettes/extending-diseasystore.Rmd
+++ b/vignettes/extending-diseasystore.Rmd
@@ -166,7 +166,7 @@ In the event, that you need to create your own aggregator the arguments are as f
 * `feature` is the name of the feature(s) to aggregate.
 
 Your aggregator should return a `dplyr::summarise()` call that operates on all columns specified in the `feature`
-argument and should return the result in a column named "n".
+argument and should return the result in a column named "value".
 
 
 ## Putting it all together


### PR DESCRIPTION
### Intent
Fixes #205

### Approach
Implement suggested solution as in #205

This revealed an oversight in the implementation of our tests.
In order for the automatic data coupling to work, each feature needs a meaningful "key_join" function, which so far has been the case for all features.

In `DiseasystoreEcdcRespiratoryViruses` the observable is a rate of disease which we cannot meaningfully aggregate automatically without population information. 

I have modified the way the "key_join" function is set for the `FeatureHandlers` to allow `key_join = NULL` as the default (to signify that no automatic coupling can occur), and I have update the documentation and tests accordingly to describe and detect these limitations.

### Known issues
~Test are failing on duckdb - unrelated to this PR (see #226)~

### Checklist

* [x] The PR passes all local unit tests
* [x] I have documented any new features introduced
* [x] If the PR adds a new feature, please add an entry in `NEWS.md`
* [x] A reviewer is assigned to this PR
