### PR TITLE
Dev lintr issue: cast back to character from glue

### DIFF
--- a/R/0_linters.R
+++ b/R/0_linters.R
@@ -297,7 +297,7 @@ param_and_field_linter <- function() {
             filename = source_expression$filename,
             line_number = line_number,
             type = "style",
-            message = glue::glue("{general_msg} {rd_type} type not declared (rd-tag is missing backticks ` )"),
+            message = as.character(glue::glue("{general_msg} {rd_type} type not declared (rd-tag is missing backticks ` )")),
             line = source_expression$file_lines[line_number]
           )
         }
@@ -310,7 +310,7 @@ param_and_field_linter <- function() {
             filename = source_expression$filename,
             line_number = line_number,
             type = "style",
-            message = glue::glue("{general_msg} {rd_type} is missing a carriage return (\\cr) after type-declaration"),
+            message = as.character(glue::glue("{general_msg} {rd_type} is missing a carriage return (\\cr) after type-declaration")),
             line = source_expression$file_lines[line_number]
           )
         }


### PR DESCRIPTION
Thanks for using lintr!

The dev version, which will be released shortly, had a breaking change -- we plan to require the `message` component of `Lint()` objects to be a plain character.

Given the short notice, in the next release, it will just be a warning, not an error, but this will change in the subsequent release.

This PR fixes the issue for diseasystore.