### PR TITLE
Fix issues with `duckdb` after v1.5.0

### DIFF
--- a/R/test_diseasystore.R
+++ b/R/test_diseasystore.R
@@ -24,6 +24,7 @@
 #'   Other parameters passed to the diseasystore generator.
 #' @return `r rd_side_effects`
 #' @examplesIf requireNamespace("duckdb", quietly = TRUE)
+#' \donttest{
 #'   # Generator for connections
 #'   conns <- \(skip_backends) list(DBI::dbConnect(duckdb::duckdb()))
 #'
@@ -35,6 +36,7 @@
 #'     test_start_date = as.Date("2020-02-20"),
 #'     skip_backends = "SQLiteConnection"
 #'   )
+#' }
 #' @importFrom curl has_internet
 #' @export
 test_diseasystore <- function(

--- a/man/test_diseasystore.Rd
+++ b/man/test_diseasystore.Rd
@@ -49,6 +49,7 @@ diseasystore before calling test_diseasystore.
 }
 \examples{
 \dontshow{if (requireNamespace("duckdb", quietly = TRUE)) withAutoprint(\{ # examplesIf}
+\donttest{
   # Generator for connections
   conns <- \(skip_backends) list(DBI::dbConnect(duckdb::duckdb()))
 
@@ -60,5 +61,6 @@ diseasystore before calling test_diseasystore.
     test_start_date = as.Date("2020-02-20"),
     skip_backends = "SQLiteConnection"
   )
+}
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
### Intent
Test are failing after `duckdb` was updated and CRAN wants us to update before 2026-03-30  

### Approach
- Issue in `add_years()` fixed by explicitly casting to `DATE`

### Known issues


### Checklist

* [ ] The PR passes all local unit tests
* [ ] I have documented any new features introduced
* [ ] If the PR adds a new feature, please add an entry in `NEWS.md`
* [ ] A reviewer is assigned to this PR
